### PR TITLE
Add contents to plugin list

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Developers in this category are in agreement with (or part of) the Pryaxis team 
 *To submit a plugin, check out the [submission](https://github.com/Pryaxis/Plugins/tree/master/submission) process.*
 
 #### Contents:
-   - [Server sided characters](#ssc-server-sided-characters)
+   - [Server side characters](#ssc-server-side-characters)
    - [PvP/PvE](#pvppve)
    - [Building](#building)
    - [Moderation](#moderation)
@@ -39,7 +39,7 @@ Developers in this category are in agreement with (or part of) the Pryaxis team 
 - 🔨 This plugin is maintained by another developer than the one who originally made it.
 - 🔗 This plugin is compatible with versions before 4.5.x
 
-### SSC (Server sided characters)
+### SSC (Server side characters)
 * Vanillafier
   * Sets up your server to run like the vanilla Terraria server in 1 easy command
   * Built on TShock 4.5.0

--- a/README.md
+++ b/README.md
@@ -24,11 +24,22 @@ Developers in this category are in agreement with (or part of) the Pryaxis team 
 
 *To submit a plugin, check out the [submission](https://github.com/Pryaxis/Plugins/tree/master/submission) process.*
 
+#### Contents:
+   - [Server sided characters](#ssc-server-sided-characters)
+   - [PvP/PvE](#pvppve)
+   - [Building](#building)
+   - [Moderation](#moderation)
+   - [Management](#management)
+   - [Worlds](#worlds)
+   - [Custom server logic](#custom-server-logic)
+   - [Chat](#chat)
+   - [Miscellaneous](#miscellaneous)
+
 #### Tags:
 - 🔨 This plugin is maintained by another developer than the one who originally made it.
 - 🔗 This plugin is compatible with versions before 4.5.x
 
-### SSC (Server side characters)
+### SSC (Server sided characters)
 * Vanillafier
   * Sets up your server to run like the vanilla Terraria server in 1 easy command
   * Built on TShock 4.5.0


### PR DESCRIPTION
### Why should you add this?
A contents sub-page will help ease scrolling through massive lists of plugins and allow easy selecting between different categories of plugins.